### PR TITLE
PCCA+ improvements utilizing DeepTime & MSMTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,5 +6,7 @@ version = "0.1.0"
 [deps]
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/Cluster.jl
+++ b/src/Cluster.jl
@@ -43,15 +43,3 @@ function assign_cluster_membership(n_states, n_clusters, eigenvectors)
     end
     return assignments
 end
-
-# If computeEigen performance isn't sufficient, use optimized eigen decomposition on sparse matrix with Arpack eigs
-# num_eigenvalues: and only compute a certain number of eigenvalues & eigenvectors
-# Cmputes eigenvalues of largest magnitude by default. See documentation: https://arpack.julialinearalgebra.org/stable/eigs/
-function compute_sparse_eigen(matrix::SparseMatrixCSC, num_eigenvalues::Int=3)
-    # converts to a sparse matrix (SparseMatrixCSC)
-    sparse_matrix = sparse(matrix)
-    eigen = eigs(sparse_matrix, nev=num_eigenvalues)
-    eigenvalues = eigen[1]
-    eigenvectors = eigen[2]
-    return eigenvalues, eigenvectors
-end

--- a/src/Cluster.jl
+++ b/src/Cluster.jl
@@ -1,22 +1,26 @@
 using LinearAlgebra
 using Arpack
+using Statistics
+using SparseArrays
+using LightGraphs
+using Optim
 
 function optimal_num_clusters(eigenvalues::Vector{Float64})
     # find index where the gap between successive eigenvalues is maximized
     gaps = diff(eigenvalues)
-    _, index = findmax(gaps)
+    _, index = findmax(abs.(gaps))
     # add 1 due to 0-indexing to get optimal number of clusters 
     opt_num_clusters = index + 1 
     return opt_num_clusters
 end
 
-function pcca(transition_matrix::Matrix{Float64})
+function pcca_simple(transition_matrix::Matrix{Float64})
     n_states = size(transition_matrix, 1)
     
     # verify transition_matrix is row stochastic (sums to 1)
     for i in 1:n_states
         if abs(sum(transition_matrix[i, :]) - 1) >= 1e-10
-            throw(ArgumentError("Row $i of transition matrix doesn't sum to 1"))
+            throw(ArgumentError("Transition matrix isn't row stochastic. Row $i doesn't sum to 1"))
         end
     end
     
@@ -29,19 +33,91 @@ function pcca(transition_matrix::Matrix{Float64})
     eigenvalues = eigenvalues[indices]
     eigenvectors = eigenvectors[:, indices]
     
-    n_clusters = optimal_num_clusters(eigenvalues)
-    assignments = assign_cluster_membership(n_states, n_clusters, eigenvectors)
+    num_clusters = optimal_num_clusters(eigenvalues)
+    assignments = assign_cluster_membership(n_states, num_clusters, eigenvectors)
     
-    return assignments, n_clusters
+    return assignments, num_clusters
 end
 
-# TODO: replace placeholder simple cluster membership function with more sophisticated function
-function assign_cluster_membership(n_states, n_clusters, eigenvectors)
+# compute membership distributions probabilities that the microstates belong to the same metastable state
+# by using the properties of slow processes in eigenvector space
+function assign_cluster_membership(n_states, num_clusters, eigenvectors)
     assignments = zeros(Int, n_states)
     for i in 1:n_states
         # assign state i to cluster with largest component in eigenvector matrix
-        _, index = findmax(abs.(eigenvectors[i, 2:n_clusters+1]))
+        _, index = findmax(abs.(eigenvectors[i, 2:num_clusters+1]))
         assignments[i] = index
     end
     return assignments
+end
+
+# Reimplementation of DeepTime PCCA in Julia
+# https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/_pcca.py#L9
+function pcca(P, num_clusters)
+    pi = compute_stationary_distribution(P)
+    memberships = pcca_memberships(P, num_clusters, pi)
+    pi_coarse_grained = memberships' * pi  # coarse-grained stationary distribution
+
+    # HMM output matrix
+    HMM_output_mat = Diagonal(1.0 ./ pi_coarse_grained) * memberships' * Diagonal(pi)
+
+    # renormalize B to make it row-stochastic
+    HMM_output_mat .= HMM_output_mat ./ sum(HMM_output_mat, dims=2)
+
+    # coarse-grained transition matrix
+    W = inv(memberships' * memberships)
+    A = memberships' * P * memberships
+    P_coarse_grained = W * A
+
+    # symmetrize & renormalize (eliminates numerical errors)
+    X = Diagonal(pi_coarse_grained) * P_coarse_grained
+    
+    # normalize to get the coarse-grained transition matrix
+    P_coarse_grained = X ./ sum(X, dims=2)
+
+    return PCCAModel(P_coarse_grained, pi_coarse_grained, memberships, HMM_output_mat)
+end
+
+# Reimplementation of DeepTime PCCAModel in Julia
+# https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/_pcca.py#L71
+abstract type Model end
+
+struct PCCAModel <: Model
+    transition_matrix_coarse::Matrix{Float64}
+    pi_coarse::Vector{Float64}
+    memberships::Matrix{Float64}
+    metastable_distributions::Matrix{Float64}
+    m::Int
+end
+
+function PCCAModel(transition_matrix_coarse::Matrix{Float64}, pi_coarse::Vector{Float64}, memberships::Matrix{Float64}, metastable_distributions::Matrix{Float64})
+    m = size(memberships, 2)
+    return PCCAModel(transition_matrix_coarse, pi_coarse, memberships, metastable_distributions, m)
+end
+
+n_metastable(model::PCCAModel) = model.m
+
+function memberships(model::PCCAModel)
+    return model.memberships
+end
+
+function metastable_distributions(model::PCCAModel)
+    return model.metastable_distributions
+end
+
+function coarse_grained_transition_matrix(model::PCCAModel)
+    return model.transition_matrix_coarse
+end
+
+function coarse_grained_stationary_probability(model::PCCAModel)
+    return model.pi_coarse
+end
+
+function assignments(model::PCCAModel)
+    return argmax(model.memberships, dims=2)
+end
+
+function sets(model::PCCAModel)
+    assignment = assignments(model)
+    return [findall(x -> x == i, assignment) for i in 1:n_metastable(model)]
 end

--- a/src/Cluster.jl
+++ b/src/Cluster.jl
@@ -15,7 +15,9 @@ function pcca(transition_matrix::Matrix{Float64})
     
     # verify transition_matrix is row stochastic (sums to 1)
     for i in 1:n_states
-        @assert abs(sum(transition_matrix[i, :]) - 1) < 1e-10 "Row $i of transition matrix doesn't sum to 1"
+        if abs(sum(transition_matrix[i, :]) - 1) >= 1e-10
+            throw(ArgumentError("Row $i of transition matrix doesn't sum to 1"))
+        end
     end
     
     # compute eigenvalues & corresponding eigenvectors

--- a/src/Cluster.jl
+++ b/src/Cluster.jl
@@ -82,11 +82,11 @@ end
 # https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/_pcca.py#L71
 abstract type Model end
 
-struct PCCAModel <: Model
-    transition_matrix_coarse::Matrix{Float64}
-    pi_coarse::Vector{Float64}
-    memberships::Matrix{Float64}
-    metastable_distributions::Matrix{Float64}
+struct PCCAModel{T} <: Model
+    transition_matrix_coarse::Matrix{T}
+    pi_coarse::Vector{T}
+    memberships::Matrix{T}
+    metastable_distributions::Matrix{T}
     m::Int
 end
 

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -36,7 +36,7 @@ function pcca_memberships(P::Matrix{Float64}, m::Int, π::Vector{Float64}=nothin
     for component in components
         rest = setdiff(1:n, component)
         # if component is closed, store with positive equilibrium distribution
-        if sum(P[component, rest]) == 0
+        if isapprox(sum(P[component, rest]), 0, atol=0.0001)
             push!(closed_components, component)
         # otherwise store as transition states with vanishing equilibrium distribution
         else

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -1,0 +1,259 @@
+using LinearAlgebra
+using Arpack
+using Statistics
+using SparseArrays
+using LightGraphs
+using Optim
+
+# NOTE: Reimplementation in Julia for select functions from MSM Tools (referenced in DeepTime)
+# https://github.com/markovmodel/msmtools
+# https://github.com/deeptime-ml/deeptime/tree/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools
+
+# Reimplementation of PCCA+ spectral clustering method with optimized memberships
+# https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools/analysis/dense/_pcca.py#L288
+function pcca_memberships(P::Matrix{Float64}, m::Int, π::Vector{Float64}=nothing)
+    n = size(P, 1)
+    if m > n
+        throw(ArgumentError("Number of metastable states m=$m exceeds number of states of transition matrix n=$n"))
+    end
+    println("P: $P")
+    if !is_transition_matrix(P)
+        throw(ArgumentError("Input matrix is not a transition matrix."))
+    end
+    if isnothing(π)
+        if ndims(π) > 1
+            throw(ArgumentError("Expected 1D stationary distribution array"))
+        elseif length(π) != n
+            throw(ArgumentError("Stationary distribution must be defined on entire space, piecewise if the transition matrix " *
+            "has multiple connected components. It covered $(length(π)) != $n states."))
+        end
+    end
+
+    chi = zeros(n, m)
+    components = connected_sets(P)
+    closed_components = []
+    transition_states = []
+    for component in components
+        rest = setdiff(1:n, component)
+        # if component is closed, store with positive equilibrium distribution
+        if sum(P[component, rest]) == 0
+            push!(closed_components, component)
+        # otherwise store as transition states with vanishing equilibrium distribution
+        else
+            push!(transition_states, component)
+        end
+    end
+
+    n_closed_components = length(closed_components)
+    closed_states = vcat(closed_components...)
+    if isempty(transition_states)
+        transition_states = Int[]
+    else
+        transition_states = vcat(transition_states...)
+    end
+
+    # check if we have enough clusters to support the disconnected sets
+    if m < n_closed_components
+        throw(error("Number of metastable states m=$m is too small. Transition matrix " *
+              "has $n_closed_components disconnected components."))
+    end
+
+    closed_components_Psub = []
+    closed_components_ev = []
+    closed_components_enum = []
+    for i in 1:n_closed_components
+        component = closed_components[i]
+        Psub = P[component, component] # compute eigenvalues in submatrix
+        push!(closed_components_Psub, Psub)
+        push!(closed_components_ev, eigen(Psub).values)
+        push!(closed_components_enum, fill(i, length(component)))
+    end
+
+    closed_components_ev_flat = vcat(closed_components_ev...)
+    closed_components_enum_flat = vcat(closed_components_enum...)
+
+    # cluster each component
+    component_indexes = closed_components_enum_flat[sortperm(closed_components_ev_flat)][1:m]
+    ipcca = 1
+    for i in 1:n_closed_components
+        component = closed_components[i]
+        m_by_component = count(x -> x == i, component_indexes) # number of PCCA states per component
+
+        if m_by_component == 1 # trivial case
+            chi[component, ipcca] .= 1.0
+            ipcca += 1
+        elseif m_by_component > 1
+            chi[component, ipcca:(ipcca + m_by_component - 1)] .= pcca_connected(
+                closed_components_Psub[i], m_by_component, π == nothing ? nothing : π[component]
+            )
+            ipcca += m_by_component
+        else
+            throw(error("Did not expect component $i to have $m_by_component."))
+        end
+    end
+
+    # assign transition states
+    if !isempty(transition_states)
+        # make all closed states absorbing, so we can see which closed state we hit first
+        Pabs = copy(P)
+        Pabs[closed_states, :] .= 0.0
+        Pabs[closed_states, closed_states] .= 1.0
+        for i in closed_states
+            h = hitting_probability(Pabs, i) # hitting probability to each closed state
+            for j in transition_states
+                chi[j, :] .+= h[j] .* chi[i, :]
+            end
+        end
+    end
+
+    nmeta = count(x -> x != 0, sum(chi, dims=1))
+    if nmeta < m
+        throw(error("Requested $m metastable states, but transition matrix only has $nmeta. " *
+                "Try requesting fewer metastable states."))
+    end
+
+    return chi
+end
+
+# Reimplementation of PCCA+ spectral clustering method with optimized memberships (assumes fully connected transition matrix)
+# https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools/analysis/dense/_pcca.py#L197
+function pcca_connected(P, n, pi=nothing)
+    labels = connected_sets(P)
+    n_components = length(labels)
+    if n_components > 1
+        throw(error("Unable to use pcca_connected, transition matrix is not fully connected."))
+    end
+
+    if pi === nothing
+        pi = stationary_distribution(P)
+    else
+        if size(pi, 1) != size(P, 1)
+            throw(error("Stationary distribution must span the entire state space but got $(size(pi, 1)) states " *
+                                "instead of $(size(P, 1))."))
+        end
+        pi ./= sum(pi)  # normalization
+    end
+
+    eigenvalues, eigenvectors = eigen(P)
+    indices = sortperm(eigenvalues, rev=true)
+    evecs = eigenvectors[:, indices]
+
+    # orthonormalize
+    for i in 1:n
+        evecs[:, i] /= sqrt(dot(evecs[:, i] .* pi, evecs[:, i]))
+    end
+
+    # make 1st eigenvector positive
+    evecs[:, 1] = abs.(evecs[:, 1])
+
+    if !all(isreal.(evecs))
+        println("Transition matrix has complex eigenvectors. Forcing eigenvectors to be real (see DeepTime note).")
+    end
+    evecs = real.(evecs)
+
+    # start with initial PCCA+ solution (can contain negative memberships)
+    chi, rot_matrix = pcca_connected_isa(evecs, n)
+
+    # optimizes PCCA+ rotation matrix s.t. memberships are always nonnegative
+    rot_matrix = opt_soft(evecs, rot_matrix, n)
+    memberships = evecs[:, :] * rot_matrix
+
+    # force memberships to be in range [0,1] (due to numerical errors)
+    memberships = max.(memberships, 0.0)
+    memberships = min.(memberships, 1.0)
+
+    for i in 1:size(memberships, 1)
+        memberships[i, :] ./= sum(memberships[i, :])
+    end
+
+    return memberships
+end
+
+# Reimplementation of PCCA+ spectral clustering method using the inner simplex algorithm.
+# https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools/analysis/dense/_pcca.py#L14
+function pcca_connected_isa(eigenvectors, num_clusters)
+    n, m = size(eigenvectors)
+    if num_clusters > m
+        throw(ArgumentError("Cannot cluster the ($n x $m) eigenvector matrix to $num_clusters clusters."))
+    end
+
+    # Check if (ONLY) 1st eigenvector is constant
+    diffs = abs.(maximum(eigenvectors, dims=1) .- minimum(eigenvectors, dims=1))
+    if diffs[1] >= 1e-6
+        throw(error("Unable to do PCCA. 1st eigenvector is not constant. The transition matrix is not connected or the eigenvectors are incorrectly sorted."))
+    end
+    if diffs[2] <= 1e-6
+        throw(error("Unable to do PCCA. An eigenvector after 1st eigenvector is constant. Potentially sorting of eigenvectors issue."))
+    end
+
+    c = eigenvectors[:, 1:num_clusters] # copy of the eigenvectors
+    ortho_sys = copy(c)
+    max_dist = 0.0
+
+    ind = zeros(Int, num_clusters) # representative states
+
+    # select 1st representative as most distant point
+    for i in 1:num_clusters
+        for j in 1:size(c, 1)
+            if norm(c[j, :]) > max_dist
+                max_dist = norm(c[j, :])
+                ind[1] = j
+            end
+        end
+    end
+
+    # translate coordinates to make the first representative the origin
+    ortho_sys .-= c[:, ind[1] + 1]
+
+    # select remaining num_clusters - 1 representatives as orthogonal to each other as possible (using Gram-Schmidt)
+    for k in 2:num_clusters
+        max_dist = 0.0
+        temp = copy(ortho_sys[ind[k - 1], :])
+        # select next farthest point that is not yet a representative
+        for i in 1:size(ortho_sys, 1)
+            row = copy(ortho_sys[i, :])
+            row .-= (temp' * row) .* temp
+            distt = norm(row, 2)
+            if distt > max_dist && i ∉ ind[1:k-1]
+                max_dist = distt
+                ind[k] = i
+            end
+        end
+        ortho_sys[ind[k], :] ./= norm(ortho_sys[ind[k], :], 2)
+    end
+
+    # transformation matrix of eigenvectors to the membership matrix
+    rot_mat = inv(c[ind, :])
+    # membership matrix
+    chi = c * rot_mat
+
+    return chi, rot_mat
+end
+
+function susanna_func(rot_crop_vec, num_clusters, eigvectors, x, y)
+    rot_crop_matrix = reshape(rot_crop_vec, x, y)
+    rot_matrix = fill_matrix(rot_crop_matrix, eigvectors)
+    
+    result = 0.0
+    for i in 1:num_clusters
+        for j in 1:num_clusters
+            result += rot_matrix[j, i]^2 / rot_matrix[1, i]
+        end
+    end
+    return -result
+end
+
+function opt_soft(eigenvectors, rot_matrix, num_clusters)
+    eigenvectors = eigenvectors[:, 1:num_clusters]
+    rot_crop_matrix = rot_matrix[2:end, 2:end]
+    
+    x, y = size(rot_crop_matrix)
+    rot_crop_vec = reshape(rot_crop_matrix, x * y)
+
+    result = optimize(opt -> susanna_func(opt, num_clusters, eigenvectors, x, y), rot_crop_vec, LBFGS(), Optim.Options(show_trace=false))
+
+    rot_crop_matrix = reshape(Optim.minimizer(result), x, y)
+    rot_matrix = fill_matrix(rot_crop_matrix, eigenvectors)
+
+    return rot_matrix
+end

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -146,7 +146,7 @@ function pcca_connected(P, n, pi=nothing)
     # make 1st eigenvector positive
     evecs[:, 1] = abs.(evecs[:, 1])
 
-    if !all(isreal.(evecs))
+    if any(x -> !isreal(x), evecs)
         println("Transition matrix has complex eigenvectors. Forcing eigenvectors to be real (see DeepTime note).")
     end
     evecs = real.(evecs)
@@ -159,8 +159,7 @@ function pcca_connected(P, n, pi=nothing)
     memberships = evecs[:, :] * rot_matrix
 
     # force memberships to be in range [0,1] (due to numerical errors)
-    memberships = max.(memberships, 0.0)
-    memberships = min.(memberships, 1.0)
+    memberships = clamp.(memberships, 0.0, 1.0)
 
     for i in 1:size(memberships, 1)
         memberships[i, :] ./= sum(memberships[i, :])

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -170,7 +170,7 @@ end
 
 # Reimplementation of PCCA+ spectral clustering method using the inner simplex algorithm.
 # https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools/analysis/dense/_pcca.py#L14
-function pcca_connected_isa(eigenvectors, num_clusters)
+function pcca_connected_isa(eigenvectors, num_clusters, tol=1e-6)
     n, m = size(eigenvectors)
     if num_clusters > m
         throw(ArgumentError("Cannot cluster the ($n x $m) eigenvector matrix to $num_clusters clusters."))
@@ -178,10 +178,10 @@ function pcca_connected_isa(eigenvectors, num_clusters)
 
     # Check if (ONLY) 1st eigenvector is constant
     diffs = abs.(maximum(eigenvectors, dims=1) .- minimum(eigenvectors, dims=1))
-    if diffs[1] >= 1e-6
+    if diffs[1] >= tol
         throw(error("Unable to do PCCA. 1st eigenvector is not constant. The transition matrix is not connected or the eigenvectors are incorrectly sorted."))
     end
-    if diffs[2] <= 1e-6
+    if diffs[2] <= tol
         throw(error("Unable to do PCCA. An eigenvector after 1st eigenvector is constant. Potentially sorting of eigenvectors issue."))
     end
 

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -45,7 +45,7 @@ function pcca_memberships(P::Matrix{Float64}, m::Int, π::Vector{Float64}=nothin
     end
 
     n_closed_components = length(closed_components)
-    closed_states = vcat(closed_components...)
+    closed_states = reduce(vcat, closed_components)
     if isempty(transition_states)
         transition_states = Int[]
     else

--- a/src/MSMToolsCluster.jl
+++ b/src/MSMToolsCluster.jl
@@ -117,22 +117,18 @@ end
 
 # Reimplementation of PCCA+ spectral clustering method with optimized memberships (assumes fully connected transition matrix)
 # https://github.com/deeptime-ml/deeptime/blob/a6ac0b93a55d688fe8f3af119680105763366220/deeptime/markov/tools/analysis/dense/_pcca.py#L197
-function pcca_connected(P, n, pi=nothing)
+function pcca_connected(P, n, π=stationary_distribution(P))
     labels = connected_sets(P)
     n_components = length(labels)
     if n_components > 1
         throw(error("Unable to use pcca_connected, transition matrix is not fully connected."))
     end
 
-    if pi === nothing
-        pi = stationary_distribution(P)
-    else
-        if size(pi, 1) != size(P, 1)
-            throw(error("Stationary distribution must span the entire state space but got $(size(pi, 1)) states " *
-                                "instead of $(size(P, 1))."))
-        end
-        pi ./= sum(pi)  # normalization
+    if size(π, 1) != size(P, 1)
+        throw(error("Stationary distribution must span the entire state space but got $(size(π, 1)) states " *
+                            "instead of $(size(P, 1))."))
     end
+    π ./= sum(π)  # normalization
 
     eigenvalues, eigenvectors = eigen(P)
     indices = sortperm(eigenvalues, rev=true)
@@ -140,7 +136,7 @@ function pcca_connected(P, n, pi=nothing)
 
     # orthonormalize
     for i in 1:n
-        evecs[:, i] /= sqrt(dot(evecs[:, i] .* pi, evecs[:, i]))
+        evecs[:, i] /= sqrt(dot(evecs[:, i] .* π, evecs[:, i]))
     end
 
     # make 1st eigenvector positive

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,5 +1,6 @@
 using LinearAlgebra
 using LightGraphs
+using SparseArrays
 
 # Various helper functions needed for clustering
 
@@ -74,14 +75,10 @@ function is_transition_matrix(T, tol=1e-12)
 end
 
 # computes hitting probabilities for all states to target states
-function hitting_probability(T, target)
+function hitting_probability(T, target::AbstractVector{<:Integer})
     if issparse(T)
         error("Needs to be sparse (no sparse implementation for now)")
     else
-        if !(target isa AbstractArray)
-            target = [target] # reformat target
-        end
-        
         n = size(T, 1)
         nontarget = setdiff(1:n, target)
         stable = findall(x -> isapprox(x, 1.0), diag(T))

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,0 +1,100 @@
+using LinearAlgebra
+using LightGraphs
+
+# Various helper functions needed for clustering
+
+# compute connected components for a directed graph, weights represented by C
+function connected_sets(C, directed=true)
+    M, _ = size(C)
+    g = SimpleGraph(M)
+    for i in 1:M
+        for j in 1:M
+            if C[i, j] != 0
+                add_edge!(g, i, j)
+            end
+        end
+    end
+
+    components = connected_components(g)
+    
+    if !directed
+        components = [sort(comp) for comp in components]
+        sort!(components, by=length, rev=true)
+    end
+    
+    return components
+end
+
+function fill_matrix(rot_crop_matrix, eigvectors)
+    x, y = size(rot_crop_matrix)
+    row_sums = sum(rot_crop_matrix, dims=2)
+    row_sums = reshape(row_sums, x, 1)
+    
+    # add -row_sums as the leftmost column to rot_crop_matrix
+    rot_crop_matrix = hcat(-row_sums, rot_crop_matrix)
+    
+    tmp = -(eigvectors[:, 2:end] * rot_crop_matrix)
+    tmp_col_max = maximum(tmp, dims=1)
+    tmp_col_max = reshape(tmp_col_max, 1, y + 1)
+    tmp_col_max_sum = sum(tmp_col_max)
+    
+    # add tmp_col_max as the top row to rot_crop_matrix and normalize
+    rot_matrix = vcat(tmp_col_max, rot_crop_matrix)
+    rot_matrix ./= tmp_col_max_sum
+    
+    return rot_matrix
+end
+
+function compute_stationary_distribution(P::Matrix{Float64})
+    n = size(P, 1)
+    A = P' - I
+    A[n, :] = ones(1, n)
+    b = zeros(n)
+    b[n] = 1.0
+    stationary_distribution = A \ b
+    return stationary_distribution
+end
+
+function is_transition_matrix(T, tol=1e-12)
+    if ndims(T) != 2 || size(T, 1) != size(T, 2)
+        return false
+    end
+
+    if issparse(T)
+        T_csr = convert(SparseMatrixCSC{eltype(T), Int}, T)
+        values = nonzeros(T_csr)
+    else
+        values = T
+    end
+
+    is_positive = isapprox(values, abs.(values), rtol=tol)
+    is_normed = isapprox(sum(T, dims=2), ones(size(T, 1)), rtol=tol)
+
+    return is_positive && is_normed
+end
+
+# computes hitting probabilities for all states to target states
+function hitting_probability(T, target)
+    if issparse(T)
+        error("Needs to be sparse (no sparse implementation for now)")
+    else
+        if !(target isa AbstractArray)
+            target = [target] # reformat target
+        end
+        
+        n = size(T, 1)
+        nontarget = setdiff(1:n, target)
+        stable = findall(x -> isapprox(x, 1.0), diag(T))
+        origin = setdiff(nontarget, stable)
+        A = T[origin, origin] - I(size(origin, 1))
+        b = sum(-T[origin, target], dims=2)
+        x = A \ b
+        
+        xfull = ones(n)
+        xfull[origin] = x
+        xfull[target] .= 1
+        xfull[stable] .= 0
+        
+        return xfull
+    end
+end


### PR DESCRIPTION
In an effort to significantly improve upon the initial simplistic implementation of PCCA, this PR utilizes the PCCA+ implementations found in the Python packages [DeepTime](https://github.com/deeptime-ml/deeptime/tree/a6ac0b93a55d688fe8f3af119680105763366220) and [MSMTools](https://github.com/markovmodel/msmtools). I've reimplemented select functions from these in Julia as an educational exercise for myself as well as to take advantages of the speedups Julia enables over Python. Documentation referring to the original functions are commented in line.

A simple test of the improved PCCA can be done with the example:
```julia
P = [0.1 0.2 0.7;
     0.3 0.4 0.3;
     0.4 0.1 0.5]
pcca_model = pcca(P, 3)
```
